### PR TITLE
make mysql env

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,10 @@ then you can view at localhost
 if you want to see logs on slack, add webhook_url to fluentd/fluent.conf
 
 https://slack.com/services/new/incoming-webhook
+
+## env
+```
+SLACK_TOKEN='xoxp-xxxxx'
+MYSQL_URL='mysql://user:pass@host/table_name'
+
+```

--- a/api-server/routes/mysqlConnection.js
+++ b/api-server/routes/mysqlConnection.js
@@ -1,12 +1,6 @@
 var mysql = require('mysql');
 
-var dbConfig = {
-  host: '127.0.0.1',
-  user: 'sun',
-  password: '1999',
-  database: 'linebot'
-};
 
-var connection = mysql.createConnection(dbConfig);
+var connection = mysql.createConnection(process.env.MYSQL_URL);
 
 module.exports = connection;


### PR DESCRIPTION
`mysql.createConnection` の引数で環境変数を参照するようにしました

> In addition to passing these options as an object, you can also use a url string. For example:
` var connection = mysql.createConnection('mysql://user:pass@host/db?debug=true&charset=BIG5_CHINESE_CI&timezone=-0700') `
https://github.com/mysqljs/mysql